### PR TITLE
Update dynamic-pages.mdx

### DIFF
--- a/workshops/fast-site-with-gatsby-js/08-dynamic-pages/dynamic-pages.mdx
+++ b/workshops/fast-site-with-gatsby-js/08-dynamic-pages/dynamic-pages.mdx
@@ -167,7 +167,7 @@ exports.createPages = async ({ actions, graphql }) => {
     }
   `);
 
-  result.allMarkdownRemark.edges.forEach(({ node }) => {
+  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
     createPage({
       path: node.frontmatter.path,
       component: blogTemplate,


### PR DESCRIPTION
Fix a missing object `data` when looping over the graphql results to create dynamic pages.